### PR TITLE
Fix errors/warnings

### DIFF
--- a/dotnet-with-nuget/Startup.cs
+++ b/dotnet-with-nuget/Startup.cs
@@ -39,10 +39,12 @@ namespace pipelines_dotnet_core
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
-
             app.UseHttpsRedirection();
             app.UseStaticFiles();
-            app.UseCookiePolicy();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {

--- a/dotnet-with-nuget/Startup.cs
+++ b/dotnet-with-nuget/Startup.cs
@@ -4,11 +4,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace pipelines_dotnet_core
 {
@@ -24,19 +23,11 @@ namespace pipelines_dotnet_core
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
-
-
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddControllersWithViews();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -53,11 +44,11 @@ namespace pipelines_dotnet_core
             app.UseStaticFiles();
             app.UseCookiePolicy();
 
-            app.UseMvc(routes =>
+            app.UseEndpoints(endpoints =>
             {
-                routes.MapRoute(
+                endpoints.MapControllerRoute(
                     name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
             });
         }
     }

--- a/dotnet-with-nuget/packages.lock.json
+++ b/dotnet-with-nuget/packages.lock.json
@@ -55,16 +55,6 @@
           "System.RunTime.InteropServices": "4.3.0"
         }
       },
-      "Microsoft.AspNet.Mvc": {
-        "type": "Direct",
-        "requested": "[5.2.7, )",
-        "resolved": "5.2.7",
-        "contentHash": "m3hUsn48k6Qb5El9A8naTwGTLCdSQKGSpGweqIfiVKltGJzAJJxuXvhhaQQtLCGg3i5V88iGjz0JG72/tlFKlg==",
-        "dependencies": {
-          "Microsoft.AspNet.Razor": "[3.2.7, 3.3.0)",
-          "Microsoft.AspNet.WebPages": "[3.2.7, 3.3.0)"
-        }
-      },
       "Microsoft.Data.OData": {
         "type": "Direct",
         "requested": "[5.8.4, )",
@@ -112,7 +102,7 @@
         "type": "Direct",
         "requested": "[2.0.0, )",
         "resolved": "2.0.0",
-        "contentHash": "LrWSncVzxP6l2rDILGKj6tXoO8ilg6M0gr/tG3QwkZ8zED1tWnBQsezBaVCOlIh4FbNA30sb0VGVH+hx+XV6MA==",
+        "contentHash": "n2xFSqmjt+H39t54zfpE5K8CO26qu0VzI6bblv1KlGSyMaA4OLnZxW4jm/NBeAprqt3mKJLFDJPeIBiXgziMmA==",
         "dependencies": {
           "NETStandard.Library": "1.0.0-rc2-23910"
         }
@@ -148,16 +138,6 @@
         "resolved": "2.9.1-dev-01151",
         "contentHash": "c835RwfGi8wcJu6G+S3A0pAGEJJRLFrPQlW1ICF90CWnqTaYYYz4quOoR3qPxlV+bHO4MyBhLq9qTC6J8ZEhtw=="
       },
-      "WebGrease": {
-        "type": "Direct",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "1d29edoh4IZPLig82coowiPBS1ltxT97PwEIkOk0dHqtJwD9v5C7gPm6Ot1hKHT86otKm04oDQ00x5c+PyVyxw==",
-        "dependencies": {
-          "Antlr": "3.4.1.9004",
-          "Newtonsoft.Json": "5.0.4"
-        }
-      },
       "WindowsAzure.Storage": {
         "type": "Direct",
         "requested": "[9.3.3, )",
@@ -177,25 +157,6 @@
           "xunit.analyzers": "0.10.0",
           "xunit.assert": "[2.4.1]",
           "xunit.core": "[2.4.1]"
-        }
-      },
-      "Antlr": {
-        "type": "Transitive",
-        "resolved": "3.4.1.9004",
-        "contentHash": "c1S+HBE+KYA5EBxtn25LEK02hHPH/tDQ6RviUTTCJpZIPoputtn8ArsQJy9lVJWZOnw37ufByO2Fmf1M8wpr8Q=="
-      },
-      "Microsoft.AspNet.Razor": {
-        "type": "Transitive",
-        "resolved": "3.2.7",
-        "contentHash": "BpWEZ+Ys7g9VAkbAfpG5jr5A1fKcmadCCXv3fYfps5YfTVABJIGV4uc9yvmXKxsNsjL+BzDld2gs+xtgT2gg1g=="
-      },
-      "Microsoft.AspNet.WebPages": {
-        "type": "Transitive",
-        "resolved": "3.2.7",
-        "contentHash": "2jwZFB7PvY+tbdz0ZP4iEo7gMrJxkCQUzoGLh6swUc6ZXl6DoKyDslmGcC/j9PFmJXCRMVIqtRorlPSMU2DuRA==",
-        "dependencies": {
-          "Microsoft.AspNet.Razor": "[3.2.7, 3.3.0)",
-          "Microsoft.Web.Infrastructure": "1.0.0"
         }
       },
       "Microsoft.CSharp": {
@@ -273,11 +234,6 @@
         "type": "Transitive",
         "resolved": "1.1.3",
         "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
-      },
-      "Microsoft.Web.Infrastructure": {
-        "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "FNmvLn5m2LTU/Rs2KWVo0SIIh9Ek+U0ojex7xeDaSHw/zgEP77A8vY5cVWgUtBGS8MJfDGNn8rpXJWEIQaPwTg=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -358,7 +314,7 @@
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "Kh9W4agE0r/hK8AX1LvyQI2NrKHBL8pO0gRoDTdDb0LL6Ta1Z2OtFx3lOaAE0ZpCUc/dt9Wzs3rA7a3IsKdOVA=="
+        "contentHash": "kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ=="
       },
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
@@ -428,7 +384,7 @@
       "System.Collections.Specialized": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "NoPBj0ykejqAWW4p4gGtrrL+3c84ZLSvGnHgq422ew1Rj4WKj1FA8/BCybqC111EtgcqUl6ZJNFYYS22HLgbjA==",
+        "contentHash": "Epx8PoVZR0iuOnJJDzp7pWvdfMMOAvpUo95pC4ScH2mJuXkKA2Y4aR3cG9qt2klHgSons1WFh4kcGW7cSXvrxg==",
         "dependencies": {
           "System.Collections.NonGeneric": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -450,7 +406,7 @@
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
         "resolved": "4.4.1",
-        "contentHash": "/8XSRz3cgSSPEdiV6UFhlfk6/FX9P10MAja4XPCyMCz7/0YTqjtCh4e0jjLYOCJL8jK7O/vhtUjYo1TOSuPngQ=="
+        "contentHash": "ToiYqSCioqhtspq2O/jYKtyTC/T0uwWHBTYlzCi6PRbSSHArN1IaRWeHffDamvms5sye5FDUWCfNZgubQpNRsA=="
       },
       "System.ComponentModel.Primitives": {
         "type": "Transitive",
@@ -923,7 +879,7 @@
       "System.Runtime.Serialization.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "2Z5t70a2SwMsfQDp9KOclaZNyQhfIga2gppq9lIUDM1A4ohTshn4JqT7ir8bvIhXgorWKYDAr6rPzEbi/nTGKg==",
+        "contentHash": "Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
         "dependencies": {
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.0"
@@ -971,7 +927,7 @@
       "System.Security.Cryptography.Csp": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "yO2k5o+Z+DiFRBvvB9vdRRAGHi6bm02M9OWXfCqQ8K0UxD3Woc3svQheZfb7PoTEFs0kGacO0IzzMWsb6Mkeow==",
+        "contentHash": "X4s/FCkEUnRGnwR3aSfVIkldBmtURMhmexALNTwpjklzxWU7yjMk7GHLKOZTNkgnWnE0q7+BCf9N2LVRWxewaA==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0",
           "System.IO": "4.3.0",
@@ -1010,7 +966,7 @@
       "System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "vOYy7Jv9KsG3ld2hLt0GoERd82SZi4BelrbXLwI9yFBYX7kpbvUCWYo4eyevk47cuJXZ9ZLVAryANcc7iY71aA==",
+        "contentHash": "h4CEgOgv5PKVF/HwaHzJRiVboL2THYCou97zpmhjghx5frc7fIvlkY1jL+lnIQyChrJDMNEXS6r7byGif8Cy4w==",
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",

--- a/dotnet-with-nuget/pipelines-dotnet-core.csproj
+++ b/dotnet-with-nuget/pipelines-dotnet-core.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Minimatch" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.*" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
@@ -24,8 +23,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0-beta1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />
-    <PackageReference Include="WebGrease" Version="1.6.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I could reproduce the content mismatch errors just by running dotnet restore locally.  If I deleted the lock file, I would get a different set of content hashes for a different set of packages, so it wasn't just a corruption somewhere.  If you look at the builds you should also see a bunch of warnings about packages not being compatible with netcore30.  It suggests that they were restored with a different target framework, but gives a bunch of options.  SInce I didn't want to give it any options at all, I fixed all those warnings (removing a couple of packages) -> this changed the content hashes on all the failing packages.  It also meant I had to do some code cleanup to make the project build again.  It now builds with no warnings or errors.